### PR TITLE
feat: Allow Element selection in the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,19 @@ Type-annotation tools like TypeScript and Flow will let you know that this isn't
 
 Refining the type of the result can be done in an `if (element !== null)...else` but this must be done every time in order to eliminate the possibility of `null`.
 
-This package allows code to rely on a `Node` being present
-- It refines a `Node | null | undefined` node into a `Node` to satisfy the type checker.
-- It returns the `Node` passed so methods can chain as usual.
-- It throws a TypeError with a customizable message if passed `null | undefined` so missing elements are caught at the point of selection.
-- It throws a TypeError if the argument passed is not a `Node`.
+This package allows code to rely on a `Node` being present:
 
-## Example
-    const element = relyOn(document.getElementById('identifier'));
+* If given a string, it selects the element with that ID and verifies it exists before returning it.
+* If given a `Node | null`, it checks the value is a `Node` and:
+  * if it is, returns it.
+  * if it is `null`, throws an Error.
+
+## Examples
+
+```javascript
+const element = relyOn("key-field", "The field must exist!");
+```
+
+```javascript
+const element = relyOn(document.querySelector(".identifier"));
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@danarthurgallagher/rely-on",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danarthurgallagher/rely-on",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Returns selected DOM elements and throws an error if they are null.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,20 @@
 export default function relyOn(
-  expectedNode: Node | null,
+  expected: string | Node | null,
   errorMessage: string = "The element is required."
 ): Node {
-  if (expectedNode === null) {
+  if (expected === null) {
     throw new TypeError(errorMessage);
-  } else if (!(expectedNode instanceof Node)) {
+  } else if (typeof expected === "string") {
+    const element = document.getElementById(expected);
+
+    if (element === null) {
+      throw new Error(errorMessage);
+    } else {
+      return element;
+    }
+  } else if (!(expected instanceof Node)) {
     throw new TypeError("The argument must be an HTMLElement or a Node.");
   } else {
-    return expectedNode;
+    return expected;
   }
 }


### PR DESCRIPTION
Now, rather than selecting the node beforehand, the module will attempt to select an element by ID if the first parameter is a string.